### PR TITLE
Fix dependency and readonly property errors

### DIFF
--- a/components/SectionHeader.js
+++ b/components/SectionHeader.js
@@ -1,8 +1,8 @@
 'use strict';
 
 var React = require('react-native');
-var {Component, PropTypes, StyleSheet, View, Text} = React;
-var UIManager = require('NativeModules').UIManager;
+var {Component, PropTypes, StyleSheet, View, Text, NativeModules} = React;
+var UIManager = NativeModules.UIManager;
 class SectionHeader extends Component {
 
   componentDidMount() {

--- a/components/SectionList.js
+++ b/components/SectionList.js
@@ -1,8 +1,8 @@
 'use strict';
 
 var React = require('react-native');
-var {Component, PropTypes, StyleSheet, View, Text} = React;
-var UIManager = require('NativeModules').UIManager;
+var {Component, PropTypes, StyleSheet, View, Text, NativeModules} = React;
+var UIManager = NativeModules.UIManager;
 
 var noop = () => {};
 var returnTrue = () => true;

--- a/components/SelectableSectionsListView.js
+++ b/components/SelectableSectionsListView.js
@@ -225,7 +225,7 @@ class SelectableSectionsListView extends Component {
       this.renderHeader :
       this.props.renderHeader;
 
-    var props = merge(this.props, {
+    var props = merge({}, this.props, {
       onScroll: this.onScroll,
       onScrollAnimationEnd: this.onScrollAnimationEnd,
       dataSource,

--- a/components/SelectableSectionsListView.js
+++ b/components/SelectableSectionsListView.js
@@ -2,8 +2,8 @@
 /* jshint esnext: true */
 
 var React = require('react-native');
-var {Component, ListView, StyleSheet, View, PropTypes} = React;
-var UIManager = require('NativeModules').UIManager;
+var {Component, ListView, StyleSheet, View, PropTypes, NativeModules} = React;
+var UIManager = NativeModules.UIManager;
 var merge = require('merge');
 
 var SectionHeader = require('./SectionHeader');

--- a/package.json
+++ b/package.json
@@ -23,5 +23,8 @@
   },
   "peerDependencies": {
     "react-native": ">=0.13.2"
+  },
+  "dependencies": {
+    "merge": "^1.2.0"
   }
 }


### PR DESCRIPTION
This PR does a few simple things:

* Specifies `merge` dependency
* References `NativeModules` module off `react-native` directly
* Uses `merge` function without mutating immutable props