### PR TITLE
Feature/support empty sections

### DIFF
--- a/components/SectionHeader.js
+++ b/components/SectionHeader.js
@@ -1,8 +1,8 @@
 'use strict';
 
 var React = require('react-native');
-var {Component, PropTypes, StyleSheet, View, Text} = React;
-var UIManager = require('NativeModules').UIManager;
+var {Component, PropTypes, StyleSheet, View, Text, NativeModules} = React;
+var UIManager = NativeModules.UIManager;
 class SectionHeader extends Component {
 
   componentDidMount() {

--- a/components/SectionList.js
+++ b/components/SectionList.js
@@ -54,7 +54,7 @@ class SectionList extends Component {
     }
     let index = Math.floor((targetY - y) / height);
     index = Math.min(index, this.props.sections.length - 1);
-    if (this.lastSelectedIndex !== index) {
+    if (this.lastSelectedIndex !== index && this.props.data[this.props.sections[index]].length) {
       this.lastSelectedIndex = index;
       this.onSectionSelect(this.props.sections[index], true);
     }

--- a/components/SectionList.js
+++ b/components/SectionList.js
@@ -83,6 +83,10 @@ class SectionList extends Component {
         this.props.getSectionListTitle(section) :
         section;
 
+      var textStyle = this.props.data[section].length ?
+        styles.text :
+        styles.inactivetext;
+
       var child = SectionComponent ?
         <SectionComponent
           sectionId={section}
@@ -90,7 +94,7 @@ class SectionList extends Component {
         /> :
         <View
           style={styles.item}>
-          <Text style={styles.text}>{title}</Text>
+          <Text style={textStyle}>{title}</Text>
         </View>;
 
       //if(index){
@@ -175,6 +179,11 @@ var styles = StyleSheet.create({
   text: {
     fontWeight: '700',
     color: '#008fff'
+  },
+
+  inactivetext: {
+    fontWeight: '700',
+    color: '#CCCCCC'
   }
 });
 

--- a/components/SectionList.js
+++ b/components/SectionList.js
@@ -1,8 +1,8 @@
 'use strict';
 
 var React = require('react-native');
-var {Component, PropTypes, StyleSheet, View, Text} = React;
-var UIManager = require('NativeModules').UIManager;
+var {Component, PropTypes, StyleSheet, View, Text, NativeModules} = React;
+var UIManager = NativeModules.UIManager;
 
 var noop = () => {};
 var returnTrue = () => true;

--- a/components/SelectableSectionsListView.js
+++ b/components/SelectableSectionsListView.js
@@ -225,7 +225,7 @@ class SelectableSectionsListView extends Component {
       this.renderHeader :
       this.props.renderHeader;
 
-    var props = merge(this.props, {
+    var props = merge({}, this.props, {
       onScroll: this.onScroll,
       onScrollAnimationEnd: this.onScrollAnimationEnd,
       dataSource,

--- a/components/SelectableSectionsListView.js
+++ b/components/SelectableSectionsListView.js
@@ -2,8 +2,8 @@
 /* jshint esnext: true */
 
 var React = require('react-native');
-var {Component, ListView, StyleSheet, View, PropTypes} = React;
-var UIManager = require('NativeModules').UIManager;
+var {Component, ListView, StyleSheet, View, PropTypes, NativeModules} = React;
+var UIManager = NativeModules.UIManager;
 var merge = require('merge');
 
 var SectionHeader = require('./SectionHeader');

--- a/components/SelectableSectionsListView.js
+++ b/components/SelectableSectionsListView.js
@@ -208,6 +208,7 @@ class SelectableSectionsListView extends Component {
           style={this.props.sectionListStyle}
           onSectionSelect={this.scrollToSection}
           sections={Object.keys(data)}
+          data={data}
           getSectionListTitle={this.props.getSectionListTitle}
           component={this.props.sectionListItem}
         /> :

--- a/package.json
+++ b/package.json
@@ -23,5 +23,8 @@
   },
   "peerDependencies": {
     "react-native": ">=0.13.2"
+  },
+  "dependencies": {
+    "merge": "^1.2.0"
   }
 }


### PR DESCRIPTION
Allow sections to be provided that have no content -- so that the whole alphabet can still be arranged, just not scroll to things.

Quick, dirty approach. Would love to discuss, would you consider opening issues on your fork?

<img width="216" alt="screen shot 2015-11-11 at 6 17 33 pm" src="https://cloud.githubusercontent.com/assets/956978/11105980/85b5feba-88a0-11e5-8f59-4cbb9ee8bdb7.png">
