### PR TITLE
Splits imports between React and React Native to fix warnings in RN 0.25

### DIFF
--- a/components/CellWrapper.js
+++ b/components/CellWrapper.js
@@ -1,12 +1,14 @@
 'use strict';
 
-var React = require('react-native');
-var {Component, PropTypes, View} = React;
+var React = require('react');
+var ReactNative = require('react-native');
+var {Component, PropTypes} = React;
+var {View} = ReactNative;
 
 class CellWrapper extends Component {
 
   componentDidMount() {
-    this.props.updateTag && this.props.updateTag(React.findNodeHandle(this.refs.view), this.props.sectionId);
+    this.props.updateTag && this.props.updateTag(ReactNative.findNodeHandle(this.refs.view), this.props.sectionId);
   }
 
   render() {

--- a/components/SectionHeader.js
+++ b/components/SectionHeader.js
@@ -1,12 +1,15 @@
 'use strict';
 
-var React = require('react-native');
-var {Component, PropTypes, StyleSheet, View, Text, NativeModules} = React;
+var React = require('react');
+var ReactNative = require('react-native');
+var {Component, PropTypes} = React;
+var {StyleSheet, View, Text, NativeModules} = ReactNative;
+
 var UIManager = NativeModules.UIManager;
 class SectionHeader extends Component {
 
   componentDidMount() {
-    this.props.updateTag && this.props.updateTag(React.findNodeHandle(this.refs.view), this.props.sectionId);
+    this.props.updateTag && this.props.updateTag(ReactNative.findNodeHandle(this.refs.view), this.props.sectionId);
   }
 
   render() {

--- a/components/SectionList.js
+++ b/components/SectionList.js
@@ -1,7 +1,9 @@
 'use strict';
 
-var React = require('react-native');
-var {Component, PropTypes, StyleSheet, View, Text, NativeModules} = React;
+var React = require('react');
+var ReactNative = require('react-native');
+var {Component, PropTypes} = React;
+var {StyleSheet, View, Text, NativeModules} = ReactNative;
 var UIManager = NativeModules.UIManager;
 
 var noop = () => {};

--- a/components/SelectableSectionsListView.js
+++ b/components/SelectableSectionsListView.js
@@ -110,12 +110,12 @@ class SelectableSectionsListView extends Component {
       var maxY = this.totalHeight - this.containerHeight + headerHeight;
       y = y > maxY ? maxY : y;
 
-      this.refs.listview.refs.listviewscroll.scrollTo({ x:0, y, animated: true });
+      this.refs.listview.scrollTo({ x:0, y, animated: true });
     } else {
       // this breaks, if not all of the listview is pre-rendered!
       UIManager.measure(this.cellTagMap[section], (x, y, w, h) => {
         y = y - this.props.sectionHeaderHeight;
-        this.refs.listview.refs.listviewscroll.scrollTo({ x:0, y, animated: true });
+        this.refs.listview.scrollTo({ x:0, y, animated: true });
       });
     }
 

--- a/components/SelectableSectionsListView.js
+++ b/components/SelectableSectionsListView.js
@@ -1,8 +1,10 @@
 'use strict';
 /* jshint esnext: true */
 
-var React = require('react-native');
-var {Component, ListView, StyleSheet, View, PropTypes, NativeModules} = React;
+var React = require('react');
+var ReactNative = require('react-native');
+var {Component, PropTypes} = React;
+var {ListView, StyleSheet, View, NativeModules} = ReactNative;
 var UIManager = NativeModules.UIManager;
 var merge = require('merge');
 
@@ -47,7 +49,7 @@ class SelectableSectionsListView extends Component {
   componentDidMount() {
     // push measuring into the next tick
     setTimeout(() => {
-      UIManager.measure(React.findNodeHandle(this.refs.view), (x,y,w,h) => {
+      UIManager.measure(ReactNative.findNodeHandle(this.refs.view), (x,y,w,h) => {
         this.containerHeight = h;
       });
     }, 0);


### PR DESCRIPTION
Also fixes #9 because the scrollTo API changed with React-native 0.25