### PR TITLE
Use UIManager.measureLayout for useDynamicHeights

### DIFF
--- a/components/SelectableSectionsListView.js
+++ b/components/SelectableSectionsListView.js
@@ -122,8 +122,7 @@ export default class SelectableSectionsListView extends Component {
 
       this.refs.listview.scrollTo({ x:0, y, animated: true });
     } else {
-      // this breaks, if not all of the listview is pre-rendered!
-      UIManager.measure(this.cellTagMap[section], (x, y, w, h) => {
+      UIManager.measureLayout(this.cellTagMap[section], ReactNative.findNodeHandle(this.refs.listview), () => {}, (x, y, w, h) => {
         y = y - this.props.sectionHeaderHeight;
         this.refs.listview.scrollTo({ x:0, y, animated: true });
       });


### PR DESCRIPTION
Looks like there are some unresolved issues surrounding measuring and using dynamic heights with Android: https://github.com/facebook/react-native/issues/4753 & https://github.com/facebook/react-native/issues/3282 in particular. 

Using measureLayout seems to resolve this issue and continues to work on both iOS and Android for now. 
