### PR TITLE
Avoid undefined view ref

### DIFF
--- a/components/SelectableSectionsListView.js
+++ b/components/SelectableSectionsListView.js
@@ -54,7 +54,7 @@ export default class SelectableSectionsListView extends Component {
   componentDidMount() {
     // push measuring into the next tick
     setTimeout(() => {
-      UIManager.measure(ReactNative.findNodeHandle(this.refs.view), (x,y,w,h) => {
+      UIManager.measure(ReactNative.findNodeHandle(this.refs.view) || 0, (x,y,w,h) => {
         this.containerHeight = h;
         if (this.props.contentInset && this.props.data && this.props.data.length > 0) {
           this.scrollToSection(Object.keys(this.props.data)[0]);


### PR DESCRIPTION
This implementation will avoid exception on some cases when `this.refs.view` is undefined and fix the problem for the issue #25