### PR TITLE
Fix scrollToSection() if not all cells have been rendered

### DIFF
--- a/components/SelectableSectionsListView.js
+++ b/components/SelectableSectionsListView.js
@@ -77,9 +77,11 @@ export default class SelectableSectionsListView extends Component {
     }
 
     this.sectionItemCount = {};
+    this.totalItemCount = 0;
     this.totalHeight = Object.keys(data)
       .reduce((carry, key) => {
         var itemCount = data[key].length;
+        this.totalItemCount += itemCount;
         carry += itemCount * this.props.cellHeight;
         carry += this.props.sectionHeaderHeight;
 
@@ -252,6 +254,7 @@ export default class SelectableSectionsListView extends Component {
       onScroll: this.onScroll,
       onScrollAnimationEnd: this.onScrollAnimationEnd,
       dataSource,
+      initialListSize: this.totalItemCount,
       renderFooter,
       renderHeader,
       renderRow: this.renderRow,


### PR DESCRIPTION
It looks like the ListView component does not render all cells initially. 
Because of this, the ScrollToSection buttons don't work until all cells have been displayed once (e.g. scroll to bottom).

Looking forward to feedback and improvement suggestions.

Note: This is merely a quick&dirty workaround. It might cause some performance penalties, as all list items will be rendered from the start.